### PR TITLE
Remove load JDK module

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -137,7 +137,6 @@ process _basecall {
 	mkdir -p \$tmp_work_dir
 
 	module load $PICARD_MODULE
-	module load $JDK_MODULE
 
 	java -jar -Xmx58g \$PICARD_JAR IlluminaBasecallsToFastq \
 		LANE=${lane} \

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,6 @@ env.archive_path=""
 env.PICARD_MODULE = "picard/2.23.8"
 env.PYTHON_MODULE = "interop/python3.6/1.1.4"
 env.PHENIQS_MODULE = "pheniqs/1.1.0"
-env.JDK_MODULE = "jdk/1.8.0_271"
 
 // nextflow work dir
 workDir = ""


### PR DESCRIPTION
No need to specify JDK module as pheniqs will load the required version.