### PR TITLE
Add conda module

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -10,6 +10,7 @@
 
 module purge
 module load nextflow/23.04.1
+module load anaconda3/2020.07
 
 run_dir_path=$1
 fcid=$2


### PR DESCRIPTION
If we enable conda in the config, we must hvae conda in the environment in the nextflow process (launch.sh). Either that or remove the `conda.enabled = true`